### PR TITLE
Add infra chart dependency ordering

### DIFF
--- a/k8s-files-helm/charts/infra/Chart.yaml
+++ b/k8s-files-helm/charts/infra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: infra
-description: Shared configuration and ingress
-version: 0.1.0
+description: Shared configuration and ingress with a simple demo Deployment
+version: 0.1.1
 type: application
 appVersion: "1.0"

--- a/k8s-files-helm/charts/infra/templates/deployment.yaml
+++ b/k8s-files-helm/charts/infra/templates/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.appName }}
+  namespace: default
+spec:
+  replicas: {{ .Values.appReplicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.appName }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.appName }}
+    spec:
+      containers:
+        - name: {{ .Values.appName }}
+          image: "{{ .Values.appImage }}:{{ .Values.appVersion }}"
+          ports:
+            - containerPort: {{ .Values.containerPort }}
+          env:
+            {{- range .Values.containerEnvVars }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}

--- a/k8s-files-helm/charts/infra/values.yaml
+++ b/k8s-files-helm/charts/infra/values.yaml
@@ -1,0 +1,7 @@
+appName: infra
+appReplicas: 1
+appImage: nginx
+appVersion: latest
+containerPort: 80
+containerTargetPort: 80
+containerEnvVars: []

--- a/k8s-files-helm/helmfile.yaml
+++ b/k8s-files-helm/helmfile.yaml
@@ -10,31 +10,47 @@ releases:
   - name: kube-ms1
     namespace: default
     chart: ./charts/command-service
+    needs:
+      - infra
 
   - name: kube-land
     namespace: default
     chart: ./charts/auth-service
+    needs:
+      - infra
 
   - name: mysql-service
     namespace: default
     chart: ./charts/mysql-service
+    needs:
+      - infra
 
   - name: elasticsearch
     namespace: default
     chart: ./charts/elasticsearch
+    needs:
+      - infra
 
   - name: logstash
     namespace: default
     chart: ./charts/logstash
+    needs:
+      - infra
 
   - name: kibana
     namespace: default
     chart: ./charts/kibana
+    needs:
+      - infra
 
   - name: zipkin
     namespace: default
     chart: ./charts/zipkin
-    
+    needs:
+      - infra
+
   - name: prometheus
     namespace: default
     chart: ./charts/prometheus
+    needs:
+      - infra


### PR DESCRIPTION
## Summary
- ensure `infra` chart deploys before all others by adding `needs` dependencies in `helmfile.yaml`

## Testing
- `helm version --short` *(fails: command not found)*