### PR TITLE
Improve helmfile timeout configuration

### DIFF
--- a/k8s-files-helm/README.md
+++ b/k8s-files-helm/README.md
@@ -14,6 +14,14 @@ This directory contains multiple Helm charts that compose the CRUD application s
 helmfile sync
 ```
 
+The helmfile is configured with a default timeout of 10 minutes, which gives
+pods extra time to become Ready. If your cluster is particularly slow you can
+override this with the `--timeout` flag:
+
+```bash
+helmfile --timeout 15m sync
+```
+
 By default all charts install into the `default` namespace and use the `local-path` storage class. These can be adjusted by overriding the `namespace` and `storageClass` values for each release.
 
 ```bash

--- a/k8s-files-helm/helmfile.yaml
+++ b/k8s-files-helm/helmfile.yaml
@@ -1,6 +1,7 @@
 helmDefaults:
   atomic: true
   wait: true
+  timeout: 600 # wait up to 10 minutes for resources to become Ready
 
 releases:
   - name: infra


### PR DESCRIPTION
## Summary
- configure a 10-minute timeout for all releases in helmfile
- document the default timeout and how to override it

## Testing
- `git status --short`