### PR TITLE
Improve chart defaults for faster deployments

### DIFF
--- a/k8s-files-helm/README.md
+++ b/k8s-files-helm/README.md
@@ -14,11 +14,23 @@ This directory contains multiple Helm charts that compose the CRUD application s
 helmfile sync
 ```
 
+The helmfile is configured with a default timeout of 10 minutes, which gives
+pods extra time to become Ready. If your cluster is particularly slow you can
+override this with the `--timeout` flag:
+
+```bash
+helmfile --timeout 15m sync
+```
+
 By default all charts install into the `default` namespace and use the `local-path` storage class. These can be adjusted by overriding the `namespace` and `storageClass` values for each release.
 
 ```bash
 helmfile -e myenv sync
 ```
+
+## Performance
+
+All charts now request more CPU and memory by default (200m CPU / 256Mi memory). Limits are set to 400m CPU / 512Mi memory, and Elasticsearch uses 1Gi memory. Container images use `IfNotPresent` pull policy to avoid unnecessary downloads. Override these values in each chart if your cluster has different resource requirements.
 
 ## Charts
 

--- a/k8s-files-helm/charts/auth-service/templates/deployment.yaml
+++ b/k8s-files-helm/charts/auth-service/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.appImage }}:{{.Values.appVersion}}"
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: {{.Values.containerPort}}
           resources:

--- a/k8s-files-helm/charts/auth-service/values.yaml
+++ b/k8s-files-helm/charts/auth-service/values.yaml
@@ -11,11 +11,11 @@ namespace: default
 storageClass: local-path
 resources:
   requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
     cpu: 200m
     memory: 256Mi
+  limits:
+    cpu: 400m
+    memory: 512Mi
 liveness:
   path: /
   initialDelaySeconds: 15

--- a/k8s-files-helm/charts/command-service/templates/deployment.yaml
+++ b/k8s-files-helm/charts/command-service/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.appImage }}:{{.Values.appVersion}}"
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: {{.Values.containerPort}}
           resources:

--- a/k8s-files-helm/charts/command-service/values.yaml
+++ b/k8s-files-helm/charts/command-service/values.yaml
@@ -11,11 +11,11 @@ namespace: default
 storageClass: local-path
 resources:
   requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
     cpu: 200m
     memory: 256Mi
+  limits:
+    cpu: 400m
+    memory: 512Mi
 liveness:
   path: /
   initialDelaySeconds: 15

--- a/k8s-files-helm/charts/elasticsearch/values.yaml
+++ b/k8s-files-helm/charts/elasticsearch/values.yaml
@@ -37,11 +37,11 @@ namespace: default
 storageClass: local-path
 resources:
   requests:
-    cpu: 100m
-    memory: 256Mi
-  limits:
     cpu: 200m
     memory: 512Mi
+  limits:
+    cpu: 400m
+    memory: 1Gi
 liveness:
   path: /
   initialDelaySeconds: 15

--- a/k8s-files-helm/charts/grafana/templates/deployment.yaml
+++ b/k8s-files-helm/charts/grafana/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.appImage }}:{{ .Values.appVersion }}"
+          imagePullPolicy: IfNotPresent
           env:
             {{- range .Values.containerEnvVars }}
             - name: {{ .name }}

--- a/k8s-files-helm/charts/grafana/values.yaml
+++ b/k8s-files-helm/charts/grafana/values.yaml
@@ -17,11 +17,11 @@ namespace: default
 storageClass: local-path
 resources:
   requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
     cpu: 200m
     memory: 256Mi
+  limits:
+    cpu: 400m
+    memory: 512Mi
 liveness:
   path: /
   initialDelaySeconds: 15

--- a/k8s-files-helm/charts/infra/templates/deployment.yaml
+++ b/k8s-files-helm/charts/infra/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.appImage }}:{{ .Values.appVersion }}"
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: {{ .Values.containerPort }}
           resources:

--- a/k8s-files-helm/charts/infra/values.yaml
+++ b/k8s-files-helm/charts/infra/values.yaml
@@ -9,11 +9,11 @@ namespace: default
 storageClass: local-path
 resources:
   requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
     cpu: 200m
     memory: 256Mi
+  limits:
+    cpu: 400m
+    memory: 512Mi
 liveness:
   path: /
   initialDelaySeconds: 15

--- a/k8s-files-helm/charts/kibana/templates/deployment.yaml
+++ b/k8s-files-helm/charts/kibana/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.appImage }}:{{.Values.appVersion}}"
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: {{.Values.containerPort}}
           resources:

--- a/k8s-files-helm/charts/kibana/values.yaml
+++ b/k8s-files-helm/charts/kibana/values.yaml
@@ -26,11 +26,11 @@ namespace: default
 storageClass: local-path
 resources:
   requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
     cpu: 200m
     memory: 256Mi
+  limits:
+    cpu: 400m
+    memory: 512Mi
 liveness:
   path: /
   initialDelaySeconds: 15

--- a/k8s-files-helm/charts/logstash/templates/deployment.yaml
+++ b/k8s-files-helm/charts/logstash/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.appImage }}:{{.Values.appVersion}}"
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: {{.Values.containerPort}}
           resources:

--- a/k8s-files-helm/charts/logstash/values.yaml
+++ b/k8s-files-helm/charts/logstash/values.yaml
@@ -31,11 +31,11 @@ namespace: default
 storageClass: local-path
 resources:
   requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
     cpu: 200m
     memory: 256Mi
+  limits:
+    cpu: 400m
+    memory: 512Mi
 liveness:
   path: /
   initialDelaySeconds: 15

--- a/k8s-files-helm/charts/mysql-service/templates/mysql.yaml
+++ b/k8s-files-helm/charts/mysql-service/templates/mysql.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.appImage }}:{{.Values.appVersion}}"
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: {{.Values.containerPort}}
           resources:

--- a/k8s-files-helm/charts/mysql-service/values.yaml
+++ b/k8s-files-helm/charts/mysql-service/values.yaml
@@ -29,11 +29,11 @@ namespace: default
 storageClass: local-path
 resources:
   requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
     cpu: 200m
     memory: 256Mi
+  limits:
+    cpu: 400m
+    memory: 512Mi
 liveness:
   path: /
   initialDelaySeconds: 15

--- a/k8s-files-helm/charts/prometheus/templates/deployment.yaml
+++ b/k8s-files-helm/charts/prometheus/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.appImage }}:{{ .Values.appVersion }}"
+          imagePullPolicy: IfNotPresent
           args:
             - '--config.file=/etc/prometheus/prometheus.yml'
             - '--storage.tsdb.path=/prometheus'

--- a/k8s-files-helm/charts/prometheus/values.yaml
+++ b/k8s-files-helm/charts/prometheus/values.yaml
@@ -9,11 +9,11 @@ namespace: default
 storageClass: local-path
 resources:
   requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
     cpu: 200m
     memory: 256Mi
+  limits:
+    cpu: 400m
+    memory: 512Mi
 liveness:
   path: /
   initialDelaySeconds: 15

--- a/k8s-files-helm/charts/zipkin/templates/deployment.yaml
+++ b/k8s-files-helm/charts/zipkin/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.appImage }}:{{.Values.appVersion}}"
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: {{.Values.containerPort}}
           resources:

--- a/k8s-files-helm/charts/zipkin/values.yaml
+++ b/k8s-files-helm/charts/zipkin/values.yaml
@@ -8,11 +8,11 @@ namespace: default
 storageClass: local-path
 resources:
   requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
     cpu: 200m
     memory: 256Mi
+  limits:
+    cpu: 400m
+    memory: 512Mi
 liveness:
   path: /
   initialDelaySeconds: 15

--- a/k8s-files-helm/helmfile.yaml
+++ b/k8s-files-helm/helmfile.yaml
@@ -1,6 +1,7 @@
 helmDefaults:
   atomic: true
   wait: true
+  timeout: 600 # wait up to 10 minutes for resources to become Ready
 
 releases:
   - name: infra


### PR DESCRIPTION
## Summary
- pull container images with `IfNotPresent` policy across all charts
- bump default CPU/Memory requests and limits for better performance
- document the new defaults in the Helmfile README

## Testing
- `git status --short`