### PR TITLE
Add envFrom support in Helm charts

### DIFF
--- a/k8s-files-helm/README.md
+++ b/k8s-files-helm/README.md
@@ -1,0 +1,30 @@
+# Helmfile Deployment
+
+This directory contains multiple Helm charts that compose the CRUD application stack. Each release is orchestrated via `helmfile.yaml`.
+
+## Prerequisites
+
+* [Helm](https://helm.sh/) installed
+* [helmfile](https://github.com/helmfile/helmfile) installed
+* A Kubernetes cluster with persistent storage support
+
+## Installation
+
+```bash
+helmfile sync
+```
+
+By default all charts install into the `default` namespace and use the `local-path` storage class. These can be adjusted by overriding the `namespace` and `storageClass` values for each release.
+
+```bash
+helmfile -e myenv sync
+```
+
+## Charts
+
+See the `charts/` directory for individual chart values.
+
+Environment variables for each deployment can be supplied directly via the
+`containerEnvVars` list or loaded from existing ConfigMaps and Secrets using
+`containerEnvFrom`. This allows an entire ConfigMap or Secret to be exposed to
+the Pod without listing each variable individually.

--- a/k8s-files-helm/charts/auth-service/templates/_helpers.tpl
+++ b/k8s-files-helm/charts/auth-service/templates/_helpers.tpl
@@ -60,3 +60,12 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Common metadata block for resources*/}}
+{{- define "app.metadata" -}}
+name: {{ .Values.appName }}
+namespace: {{ .Values.namespace }}
+labels:
+{{ include "app.labels" . | indent 2 }}
+{{- end }}

--- a/k8s-files-helm/charts/auth-service/templates/deployment.yaml
+++ b/k8s-files-helm/charts/auth-service/templates/deployment.yaml
@@ -1,22 +1,40 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.appName }}
+{{ include "app.metadata" . | indent 2 }}
 spec:
   replicas: {{ .Values.appReplicas }}
   selector:
     matchLabels:
-      app: {{ .Values.appName }}
+{{ include "app.selectorLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        app: {{ .Values.appName }}
+{{ include "app.selectorLabels" . | indent 8 }}
     spec:
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.appImage }}:{{.Values.appVersion}}"
           ports:
             - containerPort: {{.Values.containerPort}}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readiness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readiness.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.liveness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.liveness.periodSeconds }}
+          {{- if .Values.containerEnvFrom }}
+          envFrom:
+{{ toYaml .Values.containerEnvFrom | indent 12 }}
+          {{- end }}
           env:
             {{- range .Values.containerEnvVars }}
             - name: {{ .name }}
@@ -32,12 +50,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.appName }}
-  namespace: default
+{{ include "app.metadata" . | indent 2 }}
 spec:
   type: ClusterIP
   ports:
     - port:  {{.Values.containerPort}}
       targetPort:  {{.Values.containerTargetPort}}
   selector:
-    app: {{ .Values.appName }}
+{{ include "app.selectorLabels" . | indent 4 }}

--- a/k8s-files-helm/charts/auth-service/values.yaml
+++ b/k8s-files-helm/charts/auth-service/values.yaml
@@ -7,3 +7,21 @@ containerTargetPort: 8082
 containerEnvVars:
   - name: SPRING_PROFILES_ACTIVE
     value: "kubernetes"
+containerEnvFrom: []
+namespace: default
+storageClass: local-path
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+liveness:
+  path: /
+  initialDelaySeconds: 15
+  periodSeconds: 20
+readiness:
+  path: /
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/k8s-files-helm/charts/command-service/templates/deployment.yaml
+++ b/k8s-files-helm/charts/command-service/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.appName }}
+  namespace: {{ .Values.namespace }}
 spec:
   replicas: {{ .Values.appReplicas }}
   selector:
@@ -17,6 +18,24 @@ spec:
           image: "{{ .Values.appImage }}:{{.Values.appVersion}}"
           ports:
             - containerPort: {{.Values.containerPort}}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readiness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readiness.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.liveness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.liveness.periodSeconds }}
+          {{- if .Values.containerEnvFrom }}
+          envFrom:
+{{ toYaml .Values.containerEnvFrom | indent 12 }}
+          {{- end }}
           env:
             {{- range .Values.containerEnvVars }}
             - name: {{ .name }}
@@ -33,7 +52,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.appName }}
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
   type: ClusterIP
   ports:

--- a/k8s-files-helm/charts/command-service/values.yaml
+++ b/k8s-files-helm/charts/command-service/values.yaml
@@ -7,3 +7,21 @@ containerTargetPort: 8081
 containerEnvVars:
   - name: SPRING_PROFILES_ACTIVE
     value: "kubernetes"
+containerEnvFrom: []
+namespace: default
+storageClass: local-path
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+liveness:
+  path: /
+  initialDelaySeconds: 15
+  periodSeconds: 20
+readiness:
+  path: /
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/k8s-files-helm/charts/elasticsearch/templates/elasticsearch.yaml
+++ b/k8s-files-helm/charts/elasticsearch/templates/elasticsearch.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ .Values.appName }}
+  namespace: {{ .Values.namespace }}
 spec:
   serviceName: {{ .Values.appName }}
   replicas: {{ .Values.appReplicas }}
@@ -20,6 +21,10 @@ spec:
           volumeMounts:
             - name: es-data
               mountPath: /usr/share/elasticsearch/data
+          {{- if .Values.containerEnvFrom }}
+          envFrom:
+{{ toYaml .Values.containerEnvFrom | indent 12 }}
+          {{- end }}
           env:
             - name: ELASTIC_PASSWORD
               valueFrom:
@@ -34,6 +39,24 @@ spec:
               containerPort: {{.Values.containerPort}}
             - name: transport
               containerPort: {{.Values.containerTransporterPort}}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readiness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readiness.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.liveness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.liveness.periodSeconds }}
+          {{- if .Values.containerEnvFrom }}
+          envFrom:
+{{ toYaml .Values.containerEnvFrom | indent 12 }}
+          {{- end }}
           env:
             {{- range .Values.containerEnvVars }}
             - name: {{ .name }}
@@ -50,7 +73,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.appName }}
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
   type: ClusterIP
   ports:

--- a/k8s-files-helm/charts/elasticsearch/templates/pvc.yaml
+++ b/k8s-files-helm/charts/elasticsearch/templates/pvc.yaml
@@ -2,8 +2,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: es-pvc
+  namespace: {{ .Values.namespace }}
 spec:
-  storageClassName: local-path
+  storageClassName: {{ .Values.storageClass }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/k8s-files-helm/charts/elasticsearch/values.yaml
+++ b/k8s-files-helm/charts/elasticsearch/values.yaml
@@ -33,3 +33,21 @@ containerEnvVars:
   # --- JVM memory ---
   - name: ES_JAVA_OPTS
     value: "-Xms1g -Xmx1g"
+containerEnvFrom: []
+namespace: default
+storageClass: local-path
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 200m
+    memory: 512Mi
+liveness:
+  path: /
+  initialDelaySeconds: 15
+  periodSeconds: 20
+readiness:
+  path: /
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/k8s-files-helm/charts/grafana/templates/deployment.yaml
+++ b/k8s-files-helm/charts/grafana/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.appName }}
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
   replicas: {{ .Values.appReplicas }}
   selector:
@@ -16,6 +16,10 @@ spec:
       containers:
         - name: {{ .Values.appName }}
           image: "{{ .Values.appImage }}:{{ .Values.appVersion }}"
+          {{- if .Values.containerEnvFrom }}
+          envFrom:
+{{ toYaml .Values.containerEnvFrom | indent 12 }}
+          {{- end }}
           env:
             {{- range .Values.containerEnvVars }}
             - name: {{ .name }}
@@ -23,6 +27,20 @@ spec:
             {{- end }}
           ports:
             - containerPort: {{ .Values.containerPort }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readiness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readiness.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.liveness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.liveness.periodSeconds }}
           volumeMounts:
             - name: grafana-datasources
               mountPath: /etc/grafana/provisioning/datasources
@@ -44,7 +62,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.appName }}
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
   selector:
     app: {{ .Values.appName }}

--- a/k8s-files-helm/charts/grafana/templates/pvc.yaml
+++ b/k8s-files-helm/charts/grafana/templates/pvc.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: grafana-pvc
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
-  storageClassName: local-path
+  storageClassName: {{ .Values.storageClass }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/k8s-files-helm/charts/grafana/values.yaml
+++ b/k8s-files-helm/charts/grafana/values.yaml
@@ -13,3 +13,21 @@ containerEnvVars:
     value: "http://localhost/grafana/"
   - name: GF_SERVER_SERVE_FROM_SUB_PATH
     value: "true"
+containerEnvFrom: []
+namespace: default
+storageClass: local-path
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+liveness:
+  path: /
+  initialDelaySeconds: 15
+  periodSeconds: 20
+readiness:
+  path: /
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/k8s-files-helm/charts/infra/templates/configs.yaml
+++ b/k8s-files-helm/charts/infra/templates/configs.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: app-config
-  namespace: default
+  namespace: {{ .Values.namespace }}
 data:
   DB_HOST: "mysql"
   DB_NAME: "testdb"

--- a/k8s-files-helm/charts/infra/templates/deployment.yaml
+++ b/k8s-files-helm/charts/infra/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.appName }}
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
   replicas: {{ .Values.appReplicas }}
   selector:
@@ -18,6 +18,24 @@ spec:
           image: "{{ .Values.appImage }}:{{ .Values.appVersion }}"
           ports:
             - containerPort: {{ .Values.containerPort }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readiness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readiness.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.liveness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.liveness.periodSeconds }}
+          {{- if .Values.containerEnvFrom }}
+          envFrom:
+{{ toYaml .Values.containerEnvFrom | indent 12 }}
+          {{- end }}
           env:
             {{- range .Values.containerEnvVars }}
             - name: {{ .name }}

--- a/k8s-files-helm/charts/infra/templates/ingress.yaml
+++ b/k8s-files-helm/charts/infra/templates/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: main-ingress
-  namespace: default
+  namespace: {{ .Values.namespace }}
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/proxy-body-size: "10m"

--- a/k8s-files-helm/charts/infra/templates/pvc-grafana.yaml
+++ b/k8s-files-helm/charts/infra/templates/pvc-grafana.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: grafana-pvc
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
-  storageClassName: local-path
+  storageClassName: {{ .Values.storageClass }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/k8s-files-helm/charts/infra/templates/secret.yaml
+++ b/k8s-files-helm/charts/infra/templates/secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: db-credentials
-  namespace: default
+  namespace: {{ .Values.namespace }}
 type: Opaque
 data:
 
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: elk-secrets
-  namespace: default
+  namespace: {{ .Values.namespace }}
 type: Opaque
 data:
   # echo -n 'passwOrd' | base64

--- a/k8s-files-helm/charts/infra/values.yaml
+++ b/k8s-files-helm/charts/infra/values.yaml
@@ -5,3 +5,21 @@ appVersion: latest
 containerPort: 80
 containerTargetPort: 80
 containerEnvVars: []
+containerEnvFrom: []
+namespace: default
+storageClass: local-path
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+liveness:
+  path: /
+  initialDelaySeconds: 15
+  periodSeconds: 20
+readiness:
+  path: /
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/k8s-files-helm/charts/kibana/templates/deployment.yaml
+++ b/k8s-files-helm/charts/kibana/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.appName }}
+  namespace: {{ .Values.namespace }}
 spec:
   replicas: {{ .Values.appReplicas }}
   selector:
@@ -17,6 +18,24 @@ spec:
           image: "{{ .Values.appImage }}:{{.Values.appVersion}}"
           ports:
             - containerPort: {{.Values.containerPort}}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readiness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readiness.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.liveness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.liveness.periodSeconds }}
+          {{- if .Values.containerEnvFrom }}
+          envFrom:
+{{ toYaml .Values.containerEnvFrom | indent 12 }}
+          {{- end }}
           env:
             {{- range .Values.containerEnvVars }}
             - name: {{ .name }}
@@ -33,7 +52,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.appName }}
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
   type: ClusterIP
   ports:

--- a/k8s-files-helm/charts/kibana/templates/setup.yaml
+++ b/k8s-files-helm/charts/kibana/templates/setup.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: kibana-setup
+  namespace: {{ .Values.namespace }}
 spec:
   backoffLimit: 0      # Retry only once if it fails
   template:
@@ -11,6 +12,12 @@ spec:
         - name: elk-setup
           image: docker.elastic.co/elasticsearch/elasticsearch:8.12.1
           imagePullPolicy: IfNotPresent
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          {{- if .Values.containerEnvFrom }}
+          envFrom:
+{{ toYaml .Values.containerEnvFrom | indent 12 }}
+          {{- end }}
           env:
             - name: ELASTIC_PASSWORD
               valueFrom:

--- a/k8s-files-helm/charts/kibana/values.yaml
+++ b/k8s-files-helm/charts/kibana/values.yaml
@@ -22,3 +22,21 @@ containerEnvVars:
         key: kibana_password
   - name: TELEMETRY_ENABLED
     value: "false"
+containerEnvFrom: []
+namespace: default
+storageClass: local-path
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+liveness:
+  path: /
+  initialDelaySeconds: 15
+  periodSeconds: 20
+readiness:
+  path: /
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/k8s-files-helm/charts/logstash/templates/deployment.yaml
+++ b/k8s-files-helm/charts/logstash/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.appName }}
+  namespace: {{ .Values.namespace }}
 spec:
   replicas: {{ .Values.appReplicas }}
   selector:
@@ -17,6 +18,24 @@ spec:
           image: "{{ .Values.appImage }}:{{.Values.appVersion}}"
           ports:
             - containerPort: {{.Values.containerPort}}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readiness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readiness.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.liveness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.liveness.periodSeconds }}
+          {{- if .Values.containerEnvFrom }}
+          envFrom:
+{{ toYaml .Values.containerEnvFrom | indent 12 }}
+          {{- end }}
           env:
             {{- range .Values.containerEnvVars }}
             - name: {{ .name }}
@@ -33,7 +52,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.appName }}
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
   type: ClusterIP
   ports:

--- a/k8s-files-helm/charts/logstash/values.yaml
+++ b/k8s-files-helm/charts/logstash/values.yaml
@@ -24,6 +24,24 @@ containerEnvVars:
           user => "elastic"
           password => "${ELASTIC_PASSWORD}"
           ssl => false
-          index => "kube-logs"
-        }
-      }
+        index => "kube-logs"
+      } 
+    }
+containerEnvFrom: []
+namespace: default
+storageClass: local-path
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+liveness:
+  path: /
+  initialDelaySeconds: 15
+  periodSeconds: 20
+readiness:
+  path: /
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/k8s-files-helm/charts/mysql-service/templates/mysql.yaml
+++ b/k8s-files-helm/charts/mysql-service/templates/mysql.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ .Values.appName }}
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
   serviceName: {{ .Values.appName }}
   replicas: {{ .Values.appReplicas }}
@@ -19,6 +19,22 @@ spec:
           image: "{{ .Values.appImage }}:{{.Values.appVersion}}"
           ports:
             - containerPort: {{.Values.containerPort}}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readiness.periodSeconds }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.liveness.periodSeconds }}
+          {{- if .Values.containerEnvFrom }}
+          envFrom:
+{{ toYaml .Values.containerEnvFrom | indent 12 }}
+          {{- end }}
           env:
             {{- range .Values.containerEnvVars }}
             - name: {{ .name }}
@@ -42,7 +58,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.appName }}
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
   type: ClusterIP
   ports:

--- a/k8s-files-helm/charts/mysql-service/templates/pvc.yaml
+++ b/k8s-files-helm/charts/mysql-service/templates/pvc.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: mysql-pvc
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
-  storageClassName: local-path
+  storageClassName: {{ .Values.storageClass }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/k8s-files-helm/charts/mysql-service/values.yaml
+++ b/k8s-files-helm/charts/mysql-service/values.yaml
@@ -25,3 +25,21 @@ containerEnvVars:
       secretKeyRef:
         name: db-credentials
         key: DB_PASSWORD
+containerEnvFrom: []
+namespace: default
+storageClass: local-path
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+liveness:
+  path: /
+  initialDelaySeconds: 15
+  periodSeconds: 20
+readiness:
+  path: /
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/k8s-files-helm/charts/prometheus/templates/deployment.yaml
+++ b/k8s-files-helm/charts/prometheus/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.appName }}
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
   replicas: {{ .Values.appReplicas }}
   selector:
@@ -21,6 +21,24 @@ spec:
             - '--storage.tsdb.path=/prometheus'
           ports:
             - containerPort: {{ .Values.containerPort }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readiness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readiness.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.liveness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.liveness.periodSeconds }}
+          {{- if .Values.containerEnvFrom }}
+          envFrom:
+{{ toYaml .Values.containerEnvFrom | indent 12 }}
+          {{- end }}
           env:
             {{- range .Values.containerEnvVars }}
             - name: {{ .name }}
@@ -53,7 +71,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.appName }}
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
   selector:
     app: {{ .Values.appName }}

--- a/k8s-files-helm/charts/prometheus/templates/pvc.yaml
+++ b/k8s-files-helm/charts/prometheus/templates/pvc.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: prometheus-pvc
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
-  storageClassName: local-path
+  storageClassName: {{ .Values.storageClass }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/k8s-files-helm/charts/prometheus/values.yaml
+++ b/k8s-files-helm/charts/prometheus/values.yaml
@@ -5,3 +5,21 @@ appVersion: latest
 containerPort: 9090
 containerTargetPort: 9090
 containerEnvVars: []
+containerEnvFrom: []
+namespace: default
+storageClass: local-path
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+liveness:
+  path: /
+  initialDelaySeconds: 15
+  periodSeconds: 20
+readiness:
+  path: /
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/k8s-files-helm/charts/zipkin/templates/deployment.yaml
+++ b/k8s-files-helm/charts/zipkin/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.appName }}
+  namespace: {{ .Values.namespace }}
 spec:
   replicas: {{ .Values.appReplicas }}
   selector:
@@ -17,6 +18,24 @@ spec:
           image: "{{ .Values.appImage }}:{{.Values.appVersion}}"
           ports:
             - containerPort: {{.Values.containerPort}}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readiness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readiness.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.liveness.path }}
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: {{ .Values.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.liveness.periodSeconds }}
+          {{- if .Values.containerEnvFrom }}
+          envFrom:
+{{ toYaml .Values.containerEnvFrom | indent 12 }}
+          {{- end }}
           env:
             {{- range .Values.containerEnvVars }}
             - name: {{ .name }}
@@ -33,7 +52,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.appName }}
-  namespace: default
+  namespace: {{ .Values.namespace }}
 spec:
   type: ClusterIP
   ports:

--- a/k8s-files-helm/charts/zipkin/values.yaml
+++ b/k8s-files-helm/charts/zipkin/values.yaml
@@ -4,3 +4,22 @@ appImage: openzipkin/zipkin
 appVersion:
 containerPort: 9411
 containerTargetPort: 9411
+containerEnvVars: []
+containerEnvFrom: []
+namespace: default
+storageClass: local-path
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+liveness:
+  path: /
+  initialDelaySeconds: 15
+  periodSeconds: 20
+readiness:
+  path: /
+  initialDelaySeconds: 5
+  periodSeconds: 10


### PR DESCRIPTION
## Summary
- support loading env vars from ConfigMaps/Secrets via `envFrom`
- document new `containerEnvFrom` setting
- include default `containerEnvFrom` arrays in chart values

## Testing
- `helm version --short` *(fails: helm not installed)*
- `ls k8s-files-helm/charts | wc -l`